### PR TITLE
Add ONVIF files to rpm spec files

### DIFF
--- a/distros/fedora/zoneminder.cmake.f19.spec
+++ b/distros/fedora/zoneminder.cmake.f19.spec
@@ -150,10 +150,14 @@ fi
 %{_bindir}/zmwatch.pl
 %{_bindir}/zmcamtool.pl
 %{!?_without_x10:%{_bindir}/zmx10.pl}
+%{_bindir}/zmonvif-probe.pl
 
 %{perl_vendorlib}/ZoneMinder*
 %{perl_vendorlib}/%{_arch}-linux-thread-multi/auto/ZoneMinder*
-#%{perl_archlib}/ZoneMinder*
+%{perl_vendorlib}/ONVIF*
+%{perl_vendorlib}/WSDiscovery*
+%{perl_vendorlib}/WSSecurity*
+%{perl_vendorlib}/%{_arch}-linux-thread-multi/auto/ONVIF*
 %{_mandir}/man*/*
 %dir %{_libexecdir}/zoneminder
 %{_libexecdir}/zoneminder/cgi-bin
@@ -173,6 +177,9 @@ fi
 
 
 %changelog
+* Sun Aug 03 2014 Andrew Bauer <knnniggett@users.sourceforge.net> - 1.27 
+- Include ONVIF support files
+
 * Fri Mar 14 2014 Andrew Bauer <knnniggett@users.sourceforge.net> - 1.27 
 - Tweak build requirements for cmake
 

--- a/distros/fedora/zoneminder.f19.spec
+++ b/distros/fedora/zoneminder.f19.spec
@@ -241,8 +241,12 @@ fi
 %{_bindir}/zmwatch.pl
 %{_bindir}/zmcamtool.pl
 %{!?_without_x10:%{_bindir}/zmx10.pl}
+%{_bindir}/zmonvif-probe.pl
 
 %{perl_vendorlib}/ZoneMinder*
+%{perl_vendorlib}/ONVIF*
+%{perl_vendorlib}/WSDiscovery*
+%{perl_vendorlib}/WSSecurity*
 %{_mandir}/man*/*
 %dir %{_libexecdir}/zoneminder
 %{_libexecdir}/zoneminder/cgi-bin

--- a/distros/redhat/zoneminder.cmake.el6.spec
+++ b/distros/redhat/zoneminder.cmake.el6.spec
@@ -139,9 +139,14 @@ rm -rf %{_docdir}/%{name}-%{version}
 %{_bindir}/zmwatch.pl
 %{_bindir}/zmcamtool.pl
 %{_bindir}/zmx10.pl
+%{_bindir}/zmonvif-probe.pl
 
 %{perl_vendorlib}/ZoneMinder*
 %{perl_vendorlib}/%{_arch}-linux-thread-multi/auto/ZoneMinder*
+%{perl_vendorlib}/ONVIF*
+%{perl_vendorlib}/WSDiscovery*
+%{perl_vendorlib}/WSSecurity*
+%{perl_vendorlib}/%{_arch}-linux-thread-multi/auto/ONVIF*
 %{_mandir}/man*/*
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/cgi-bin
@@ -160,6 +165,9 @@ rm -rf %{_docdir}/%{name}-%{version}
 
 
 %changelog
+* Sun Aug 03 2014 Andrew Bauer <knnniggett@users.sourceforge.net> - 1.27 
+- Include ONVIF support files
+
 * Fri Mar 14 2014 Andrew Bauer <knnniggett@users.sourceforge.net> - 1.27 
 - Tweak build requirements for cmake
 

--- a/distros/redhat/zoneminder.el6.spec
+++ b/distros/redhat/zoneminder.el6.spec
@@ -246,8 +246,12 @@ fi
 %{_bindir}/zmwatch.pl
 %{_bindir}/zmcamtool.pl
 %{_bindir}/zmx10.pl
+%{_bindir}/zmonvif-probe.pl
 
 %{perl_vendorlib}/ZoneMinder*
+%{perl_vendorlib}/ONVIF*
+%{perl_vendorlib}/WSDiscovery*
+%{perl_vendorlib}/WSSecurity*
 %{_mandir}/man*/*
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/cgi-bin
@@ -266,6 +270,9 @@ fi
 
 
 %changelog
+* Sun Aug 03 2014 Andrew Bauer <knnniggett@users.sourceforge.net> - 1.27 
+- Include ONVIF support files
+
 * Sat Feb 01 2014 Andrew Bauer <knnniggett@users.sourceforge.net> - 1.27
 - Add zmcamtool.pl. Bump version for 1.27 release. 
 


### PR DESCRIPTION
Adds the necessary rpm packaging changes to incorporate the new ONVIF files.  Changes redhat & fedora spec files.  OpenSuse globs all folders in the buildroot so no changes where necessary for that distro.
